### PR TITLE
Build shared library directly

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -3373,7 +3373,7 @@ Python/thread.o: @THREADHEADERS@ $(srcdir)/Python/condvar.h
 ##########################################################################
 # Module dependencies and platform-specific files
 
-cpython-sys: Modules/cpython-sys/Cargo.toml Modules/cpython-sys/build.rs Modules/cpython-sys/wrapper.h Modules/cpython-sys/parser.h
+cpython-sys: $(LIBPYTHON) Modules/cpython-sys/Cargo.toml Modules/cpython-sys/build.rs Modules/cpython-sys/wrapper.h Modules/cpython-sys/parser.h
 	CARGO_TARGET_DIR=$(abs_builddir)/target PYTHON_BUILD_DIR=$(abs_builddir) \$(CARGO_HOME)/bin/cargo build --lib --locked --package cpython-sys --profile $(CARGO_PROFILE) $(if $(CARGO_TARGET),--target=$(CARGO_TARGET)) --manifest-path $(srcdir)/Cargo.toml
 
 # force rebuild when header file or module build flavor (static/shared) is changed

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -3373,7 +3373,7 @@ Python/thread.o: @THREADHEADERS@ $(srcdir)/Python/condvar.h
 ##########################################################################
 # Module dependencies and platform-specific files
 
-cpython-sys: $(LIBPYTHON) Modules/cpython-sys/Cargo.toml Modules/cpython-sys/build.rs Modules/cpython-sys/wrapper.h Modules/cpython-sys/parser.h
+cpython-sys: $(LIBRARY) Modules/cpython-sys/Cargo.toml Modules/cpython-sys/build.rs Modules/cpython-sys/wrapper.h Modules/cpython-sys/parser.h
 	CARGO_TARGET_DIR=$(abs_builddir)/target PYTHON_BUILD_DIR=$(abs_builddir) \$(CARGO_HOME)/bin/cargo build --lib --locked --package cpython-sys --profile $(CARGO_PROFILE) $(if $(CARGO_TARGET),--target=$(CARGO_TARGET)) --manifest-path $(srcdir)/Cargo.toml
 
 # force rebuild when header file or module build flavor (static/shared) is changed

--- a/Modules/Setup
+++ b/Modules/Setup
@@ -182,7 +182,7 @@ PYTHONPATH=$(COREPYTHONPATH)
 #_codecs_tw cjkcodecs/_codecs_tw.c
 #_multibytecodec cjkcodecs/multibytecodec.c
 #unicodedata unicodedata.c
-#_base64 _base64/Cargo.toml _base64/src/lib.rs lib_base64.a
+#_base64 _base64/Cargo.toml _base64/src/lib.rs
 
 # Modules with some UNIX dependencies
 

--- a/Modules/Setup.stdlib.in
+++ b/Modules/Setup.stdlib.in
@@ -120,7 +120,7 @@
 ############################################################################
 # Rust modules
 #
-@MODULE__BASE64_TRUE@_base64 _base64/Cargo.toml _base64/src/lib.rs lib_base64.a
+@MODULE__BASE64_TRUE@_base64 _base64/Cargo.toml _base64/src/lib.rs
 
 ############################################################################
 # Modules with some UNIX dependencies

--- a/Modules/_base64/Cargo.toml
+++ b/Modules/_base64/Cargo.toml
@@ -8,4 +8,4 @@ cpython-sys ={ path = "../cpython-sys" }
 
 [lib]
 name = "_base64"
-crate-type = ["staticlib"]
+crate-type = ["cdylib"]

--- a/Modules/_base64/src/lib.rs
+++ b/Modules/_base64/src/lib.rs
@@ -115,7 +115,6 @@ impl Drop for BorrowedBuffer {
 /// # Safety
 /// `module` must be a valid pointer of PyObject representing the module.
 /// `args` must be a valid pointer to an array of valid PyObject pointers with length `nargs`.
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn standard_b64encode(
     _module: *mut PyObject,
     args: *mut *mut PyObject,
@@ -193,13 +192,11 @@ fn standard_b64encode_impl(source: &PyObject) -> Result<*mut PyObject, ()> {
     Ok(result)
 }
 
-#[unsafe(no_mangle)]
 pub extern "C" fn _base64_clear(_obj: *mut PyObject) -> c_int {
     //TODO
     0
 }
 
-#[unsafe(no_mangle)]
 pub extern "C" fn _base64_free(_o: *mut c_void) {
     //TODO
 }

--- a/Modules/cpython-sys/build.rs
+++ b/Modules/cpython-sys/build.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::path::{Path, PathBuf};
 
 fn main() {
+    println!("cargo::rerun-if-env-changed=LIBPYTHON");
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let srcdir = manifest_dir
         .parent()
@@ -11,6 +12,11 @@ fn main() {
     let builddir = env::var("PYTHON_BUILD_DIR").ok();
     if gil_disabled(srcdir, builddir.as_deref()) {
         println!("cargo:rustc-cfg=py_gil_disabled");
+    }
+    if let Ok(libpython) = env::var("LIBPYTHON")
+        && libpython.len() != 0
+    {
+        println!("cargo::rustc-link-lib=static={}", libpython);
     }
     generate_c_api_bindings(srcdir, builddir.as_deref(), out_path.as_path());
     // TODO(emmatyping): generate bindings to the internal parser API

--- a/Modules/cpython-sys/build.rs
+++ b/Modules/cpython-sys/build.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::{Path, PathBuf};
 
 fn main() {
-    println!("cargo::rerun-if-env-changed=LIBPYTHON");
+    println!("cargo::rerun-if-env-changed=LIBRARY");
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let srcdir = manifest_dir
         .parent()
@@ -13,7 +13,7 @@ fn main() {
     if gil_disabled(srcdir, builddir.as_deref()) {
         println!("cargo:rustc-cfg=py_gil_disabled");
     }
-    if let Ok(libpython) = env::var("LIBPYTHON")
+    if let Ok(libpython) = env::var("LIBRARY")
         && libpython.len() != 0
     {
         println!("cargo::rustc-link-lib=static={}", libpython);

--- a/Modules/makesetup
+++ b/Modules/makesetup
@@ -308,7 +308,7 @@ sed -e 's/[ 	]*#.*//' -e '/^[ 	]*$/d' |
 					;;
 				esac
 				# depends on the headers through cpython-sys
-				rule="$rust_shared: cpython-sys \$(srcdir)/Cargo.toml \$(srcdir)/Cargo.lock \$(srcdir)/$srcdir/$manifest $prefixed_srcs \$(PYTHON_HEADERS) \$(MODULE_${mods_upper}_LDEPS) \$(LIBPYTHON)"
+				rule="$rust_shared: cpython-sys \$(srcdir)/Cargo.toml \$(srcdir)/Cargo.lock \$(srcdir)/$srcdir/$manifest $prefixed_srcs \$(PYTHON_HEADERS) \$(MODULE_${mods_upper}_LDEPS) \$(LIBRARY)"
 				rule="$rule; CARGO_TARGET_DIR=\$(abs_builddir)/target PYTHON_BUILD_DIR=\$(abs_builddir) \$(CARGO_HOME)/bin/cargo build --lib --locked --package ${mod} --profile \$(CARGO_PROFILE) \$(if \$(CARGO_TARGET),--target=\$(CARGO_TARGET)) --manifest-path \$(srcdir)/Cargo.toml"
 				echo "$rule" >>$rulesf
 				echo "$file: $rust_shared; mv $rust_shared $file" >>$rulesf

--- a/Modules/makesetup
+++ b/Modules/makesetup
@@ -232,7 +232,6 @@ sed -e 's/[ 	]*#.*//' -e '/^[ 	]*$/d' |
 		yes)	continue;;
 		esac
 		objs=''
-		custom_ldflags=''
 		if test "x$rust" = "x"; then
 			for src in $srcs
 			do
@@ -272,6 +271,23 @@ sed -e 's/[ 	]*#.*//' -e '/^[ 	]*$/d' |
 				esac
 				echo "$rule" >>$rulesf
 			done
+
+			case $doconfig in
+			yes)	OBJS="$OBJS $objs";;
+			esac
+			for mod in $mods
+			do
+				file="$srcdir/$mod\$(EXT_SUFFIX)"
+				case $doconfig in
+				no)
+					SHAREDMODS="$SHAREDMODS $file"
+					BUILT_SHARED="$BUILT_SHARED $mod"
+					;;
+				esac
+				rule="$file: $objs \$(MODULE_${mods_upper}_LDEPS)"
+				rule="$rule; \$(BLDSHARED) $objs $libs \$(LIBPYTHON) -o $file"
+				echo "$rule" >>$rulesf
+			done
 		else
 			prefixed_srcs=
 			for src in $srcs
@@ -279,44 +295,25 @@ sed -e 's/[ 	]*#.*//' -e '/^[ 	]*$/d' |
 				prefixed_srcs="$prefixed_srcs $srcdir/$src"
 			done
 			objs=
-			# there's actually only one obj, so just set it to the lib
-			for lib in $libs
-			do
-				objs="target/\$(if \$(CARGO_TARGET),\$(CARGO_TARGET)/\$(CARGO_TARGET_DIR),\$(CARGO_TARGET_DIR))/$lib"
-			done
 			libs=
-			# depends on the headers through cpython-sys
-			rule="$objs: cpython-sys \$(srcdir)/Cargo.toml \$(srcdir)/Cargo.lock \$(srcdir)/$srcdir/$manifest $prefixed_srcs \$(PYTHON_HEADERS)"
-			rule="$rule; CARGO_TARGET_DIR=\$(abs_builddir)/target PYTHON_BUILD_DIR=\$(abs_builddir) \$(CARGO_HOME)/bin/cargo build --lib --locked --package ${mods} --profile \$(CARGO_PROFILE) \$(if \$(CARGO_TARGET),--target=\$(CARGO_TARGET)) --manifest-path \$(srcdir)/Cargo.toml"
-			echo "$rule" >>$rulesf
+
 			for mod in $mods
 			do
-				case $UNAME_SYSTEM in
-				Darwin*)
-					custom_ldflags="$custom_ldflags -Wl,-u,_PyInit_$mod"
-					;;
-				*)
-					custom_ldflags="$custom_ldflags -Wl,--defsym=PyInit_$mod=PyInit_$mod"
+				rust_shared="target/\$(CARGO_TARGET)/\$(CARGO_TARGET_DIR)/lib$mod\$(SHLIB_SUFFIX)"
+				file="$srcdir/$mod\$(EXT_SUFFIX)"
+				case $doconfig in
+				no)
+					SHAREDMODS="$SHAREDMODS $file"
+					BUILT_SHARED="$BUILT_SHARED $mod"
 					;;
 				esac
+				# depends on the headers through cpython-sys
+				rule="$rust_shared: cpython-sys \$(srcdir)/Cargo.toml \$(srcdir)/Cargo.lock \$(srcdir)/$srcdir/$manifest $prefixed_srcs \$(PYTHON_HEADERS) \$(MODULE_${mods_upper}_LDEPS) \$(LIBPYTHON)"
+				rule="$rule; CARGO_TARGET_DIR=\$(abs_builddir)/target PYTHON_BUILD_DIR=\$(abs_builddir) \$(CARGO_HOME)/bin/cargo build --lib --locked --package ${mod} --profile \$(CARGO_PROFILE) \$(if \$(CARGO_TARGET),--target=\$(CARGO_TARGET)) --manifest-path \$(srcdir)/Cargo.toml"
+				echo "$rule" >>$rulesf
+				echo "$file: $rust_shared; mv $rust_shared $file" >>$rulesf
 			done
 		fi
-		case $doconfig in
-		yes)	OBJS="$OBJS $objs";;
-		esac
-		for mod in $mods
-		do
-			file="$srcdir/$mod\$(EXT_SUFFIX)"
-			case $doconfig in
-			no)
-				SHAREDMODS="$SHAREDMODS $file"
-				BUILT_SHARED="$BUILT_SHARED $mod"
-				;;
-			esac
-			rule="$file: $objs \$(MODULE_${mods_upper}_LDEPS)"
-			rule="$rule; \$(BLDSHARED) $custom_ldflags $objs $libs \$(LIBPYTHON) -o $file"
-			echo "$rule" >>$rulesf
-		done
 	done
 
 	case $SHAREDMODS in

--- a/configure
+++ b/configure
@@ -36187,3 +36187,4 @@ if test "$ac_cv_header_stdatomic_h" != "yes"; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Your compiler or platform does have a working C11 stdatomic.h. A future version of Python may require stdatomic.h." >&5
 printf "%s\n" "$as_me: Your compiler or platform does have a working C11 stdatomic.h. A future version of Python may require stdatomic.h." >&6;}
 fi
+


### PR DESCRIPTION
This commit modifies the build system to directly generate shared objects rather than generating a static library that is linked to libpython into a shared object. This removes the link hack that we currently use.

The downside is that we should probably figure out a way to handle custom linker flags and customization of `BLDSHARED`.
