### PR TITLE
Disable rust when sanitizers are active

### DIFF
--- a/configure
+++ b/configure
@@ -16141,7 +16141,7 @@ fi
 
 
 
-if test "$with_asan" == "yes" || "$with_msan" == "yes" || "$with_ubsan" == "yes" || "$with_tsan" == "yes";
+if test "$with_msan" == "yes" || "$with_ubsan" == "yes" || "$with_tsan" == "yes";
 then
   HAVE_CARGO="no"
 fi

--- a/configure
+++ b/configure
@@ -13376,12 +13376,16 @@ then :
 printf "%s\n" "$withval" >&6; }
 BASECFLAGS="-fsanitize=address -fno-omit-frame-pointer $BASECFLAGS"
 LDFLAGS="-fsanitize=address $LDFLAGS"
+with_asan="yes"
 # ASan works by controlling memory allocation, our own malloc interferes.
 with_pymalloc="no"
 
 else case e in #(
-  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; } ;;
+  e)
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+with_asan="no"
+ ;;
 esac
 fi
 
@@ -13433,6 +13437,7 @@ then :
 
 BASECFLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer $BASECFLAGS"
 LDFLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2 $LDFLAGS"
+with_msan="yes"
 
 else case e in #(
   e) as_fn_error $? "The selected compiler doesn't support memory sanitizer" "$LINENO" 5 ;;
@@ -13441,10 +13446,14 @@ fi
 
 # MSan works by controlling memory allocation, our own malloc interferes.
 with_pymalloc="no"
+with_msan="no"
 
 else case e in #(
-  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; } ;;
+  e)
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+with_msan="no"
+ ;;
 esac
 fi
 
@@ -16131,6 +16140,11 @@ fi
 
 
 
+
+if test "$with_asan" == "yes" || "$with_msan" == "yes" || "$with_ubsan" == "yes" || "$with_tsan" == "yes";
+then
+  HAVE_CARGO="no"
+fi
 
 
 
@@ -36187,3 +36201,4 @@ if test "$ac_cv_header_stdatomic_h" != "yes"; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Your compiler or platform does have a working C11 stdatomic.h. A future version of Python may require stdatomic.h." >&5
 printf "%s\n" "$as_me: Your compiler or platform does have a working C11 stdatomic.h. A future version of Python may require stdatomic.h." >&6;}
 fi
+

--- a/configure.ac
+++ b/configure.ac
@@ -3316,10 +3316,14 @@ AC_ARG_WITH([address_sanitizer],
 AC_MSG_RESULT([$withval])
 BASECFLAGS="-fsanitize=address -fno-omit-frame-pointer $BASECFLAGS"
 LDFLAGS="-fsanitize=address $LDFLAGS"
+with_asan="yes"
 # ASan works by controlling memory allocation, our own malloc interferes.
 with_pymalloc="no"
 ],
-[AC_MSG_RESULT([no])])
+[
+AC_MSG_RESULT([no])
+with_asan="no"
+])
 
 AC_MSG_CHECKING([for --with-memory-sanitizer])
 AC_ARG_WITH(
@@ -3333,11 +3337,16 @@ AC_MSG_RESULT([$withval])
 AX_CHECK_COMPILE_FLAG([-fsanitize=memory],[
 BASECFLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer $BASECFLAGS"
 LDFLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2 $LDFLAGS"
+with_msan="yes"
 ],[AC_MSG_ERROR([The selected compiler doesn't support memory sanitizer])])
 # MSan works by controlling memory allocation, our own malloc interferes.
 with_pymalloc="no"
+with_msan="no"
 ],
-[AC_MSG_RESULT([no])])
+[
+AC_MSG_RESULT([no])
+with_msan="no"
+])
 
 AC_MSG_CHECKING([for --with-undefined-behavior-sanitizer])
 AC_ARG_WITH(
@@ -4354,6 +4363,13 @@ AC_SUBST([CARGO_HOME])
 AC_SUBST([CARGO_TARGET_DIR])
 AC_SUBST([CARGO_PROFILE])
 AC_SUBST([CARGO_TARGET])
+
+dnl do not enable Rust code if sanitizers are enabled
+dnl this should be fixed in the future to use unstable sanitizer support
+if test "$with_asan" == "yes" || "$with_msan" == "yes" || "$with_ubsan" == "yes" || "$with_tsan" == "yes";
+then
+  HAVE_CARGO="no"
+fi
 
 
 dnl detect sqlite3 from Emscripten emport

--- a/configure.ac
+++ b/configure.ac
@@ -4364,9 +4364,10 @@ AC_SUBST([CARGO_TARGET_DIR])
 AC_SUBST([CARGO_PROFILE])
 AC_SUBST([CARGO_TARGET])
 
-dnl do not enable Rust code if sanitizers are enabled
-dnl this should be fixed in the future to use unstable sanitizer support
-if test "$with_asan" == "yes" || "$with_msan" == "yes" || "$with_ubsan" == "yes" || "$with_tsan" == "yes";
+dnl do not enable Rust code if certain sanitizers are enabled
+dnl asan works fine, but msan requires the entire binary to be instrumented
+dnl ubsan and tsan cause the bindings generation to fail, so they are disabled for now
+if test "$with_msan" == "yes" || "$with_ubsan" == "yes" || "$with_tsan" == "yes";
 then
   HAVE_CARGO="no"
 fi


### PR DESCRIPTION
In a follow up, we should enable sanitizers using nightly and the unstable sanitizers support, which works with all CPython sanitizers except undefined-behavior sanitizer.

Unstable sanitizers support: https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html