### PR TITLE
Make Rust CI workflows zizmor compliant

### DIFF
--- a/.github/setup-rust-windows/action.yml
+++ b/.github/setup-rust-windows/action.yml
@@ -11,8 +11,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: dtolnay/rust-toolchain@1.91.1
+    - uses: dtolnay/rust-toolchain@ab40b01f54fe82bdf65693ea090a1e4942c136e7 # 1.91.1
       with:
+        toolchain: 1.91.1
         targets: i686-pc-windows-msvc,x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
     # LIBCLANG_PATH must be set explicitly so the vcxproj uses the LLVM we
     # install here rather than the VS-bundled LLVM whose clang headers have
@@ -20,11 +21,11 @@ runs:
     # controlled input), so the GITHUB_ENV writes are safe.
     - name: Install LLVM for bindgen
       if: inputs.arch != 'arm64'
-      shell: cmd
+      shell: pwsh
       run: | # zizmor: ignore[github-env]
         choco install llvm --allow-downgrade --no-progress --version 21.1.0
-        if not exist "C:\Program Files\LLVM\bin\libclang.dll" exit /b 1
-        echo LIBCLANG_PATH=C:\Program Files\LLVM\bin>> "%GITHUB_ENV%"
+        if (!(Test-Path 'C:\Program Files\LLVM\bin\libclang.dll')) { exit 1 }
+        echo "LIBCLANG_PATH=C:\Program Files\LLVM\bin" >> $env:GITHUB_ENV
     # Chocolatey's LLVM package only ships x64 binaries, which an ARM64-native
     # cargo process cannot load.  Install the official ARM64 build directly.
     - name: Install LLVM for bindgen (ARM64)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -353,8 +353,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@1.91.1
+      - uses: dtolnay/rust-toolchain@ab40b01f54fe82bdf65693ea090a1e4942c136e7 # 1.91.1
         with:
+          toolchain: 1.91.1
           targets: ${{ matrix.arch }}-linux-android
       - name: Build and test
         run: JAVA_HOME="${JAVA_HOME_21_X64:-$JAVA_HOME_21_arm64}" python3 Platforms/Android ci --fast-ci ${{ matrix.arch }}-linux-android
@@ -369,8 +370,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@1.91.1
+      - uses: dtolnay/rust-toolchain@ab40b01f54fe82bdf65693ea090a1e4942c136e7 # 1.91.1
         with:
+          toolchain: 1.91.1
           targets: aarch64-apple-ios-sim
       # GitHub recommends explicitly selecting the desired Xcode version:
       # https://github.com/actions/runner-images/issues/12541#issuecomment-3083850140

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -15,10 +15,10 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           toolchain: stable
       - run: ./configure

--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -47,8 +47,9 @@ jobs:
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.x'
-    - uses: dtolnay/rust-toolchain@1.91.1
+    - uses: dtolnay/rust-toolchain@ab40b01f54fe82bdf65693ea090a1e4942c136e7 # 1.91.1
       with:
+        toolchain: 1.91.1
         targets: wasm32-wasip1
     - name: "Runner image version"
       run: echo "IMAGE_OS_VERSION=${ImageOS}-${ImageVersion}" >> "$GITHUB_ENV"


### PR DESCRIPTION
The Rust CI additions introduced action references that the repository's zizmor blanket policy flags: 6 `unpinned-uses` errors and 1 `misfeature` finding (see the [failing run](https://github.com/Rust-for-CPython/cpython/actions/runs/29635827292/job/88057864868)).

This pins every action in the Rust CI files to a full commit SHA (with a version comment), matching how the rest of the repo pins its actions:

- `dtolnay/rust-toolchain@1.91.1` → `ab40b01f54fe82bdf65693ea090a1e4942c136e7 # 1.91.1` (in `setup-rust-windows/action.yml`, `build.yml` ×2, `reusable-wasi.yml`)
- `dtolnay/rust-toolchain@stable` → `4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable` (`cargo.yml`)
- `actions/checkout@v6` → `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0` (`cargo.yml`), the same pin used everywhere else in the repo

`dtolnay/rust-toolchain` derives the toolchain from the action ref, so hash-pinning it breaks that inference. I've added an explicit `toolchain:` input wherever it was pinned to a hash and one wasn't already present.

For the remaining `misfeature` finding, the x64 *Install LLVM for bindgen* step is switched from `shell: cmd` to `shell: pwsh`, mirroring the existing ARM64 step in the same file (same `Test-Path` guard and `GITHUB_ENV` write).

Fixes #37
